### PR TITLE
Add functionality to the remove button

### DIFF
--- a/src/components/RuleGroup.js
+++ b/src/components/RuleGroup.js
@@ -25,11 +25,11 @@ const groupGridStyles = makeStyles({
 function RuleGroup({
   ruleGroupName,
   addChildToGroup,
+  removeRuleGroup,
   isTopGroup = false,
   children,
 }) {
   const groupClasses = groupGridStyles();
-
   const { initialValues } = useSQFormContext();
 
   // Check if the initial values for this group exist yet
@@ -41,6 +41,8 @@ function RuleGroup({
   if (!initialValue) {
     return null;
   }
+
+  const isRemoveDisabled = children && children.length;
 
   return (
     <Grid container spacing={2} justify="flex-start" className={groupClasses.groupGrid}>
@@ -71,13 +73,15 @@ function RuleGroup({
           Add Rule
         </Button>
         {!isTopGroup && (
-        <Button
-          className={groupClasses.groupButton}
-          variant="contained"
-          size="small"
-        >
-          Remove
-        </Button>
+          <Button
+            className={groupClasses.groupButton}
+            variant="contained"
+            size="small"
+            disabled={!!isRemoveDisabled}
+            onClick={() => { removeRuleGroup(ruleGroupName); }}
+          >
+            Remove
+          </Button>
         )}
       </Grid>
       <Grid item sm={3} />
@@ -96,6 +100,8 @@ RuleGroup.propTypes = {
   ruleGroupName: PropTypes.string.isRequired,
   /** Add child to group function */
   addChildToGroup: PropTypes.func.isRequired,
+  /** Function to remove this group entirely */
+  removeRuleGroup: PropTypes.func.isRequired,
   /** Whether this group is the top group */
   isTopGroup: PropTypes.bool,
   /** The rules or group that are a part of this group */

--- a/src/components/RuleGroupDisplay.js
+++ b/src/components/RuleGroupDisplay.js
@@ -1,68 +1,27 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Grid } from '@material-ui/core';
-import { v4 as uuidv4 } from 'uuid';
 import getRuleElementsFromSchema from '../util/getRuleElementsFromSchema';
 import conditionSchemaPropType from '../util/proptypes';
-import { GROUP_TYPE, RULE_TYPE } from '../constants/constants';
+import buildNewSchemaWithAddition from '../util/buildNewSchemaWithAddition';
+import buildNewSchemaWithRemoval from '../util/buildNewSchemaWithRemoval';
 
 function RuleGroupDisplay({
   livingConditionSchema,
   setLivingConditionSchema,
 }) {
   const addChildToGroup = React.useCallback((ruleGroupName, childTypeToAdd) => {
-    const buildNewSchema = (existingSchema) => {
-      let newConditionSchema = {};
-      if (existingSchema.id === ruleGroupName) {
-        newConditionSchema = {
-          ...newConditionSchema,
-          ...existingSchema,
-          children: [
-            ...existingSchema.children,
-            (childTypeToAdd === GROUP_TYPE && {
-              type: GROUP_TYPE,
-              id: uuidv4(),
-              condition: 'all',
-              children: [],
-            }),
-            (childTypeToAdd === RULE_TYPE && {
-              type: RULE_TYPE,
-              id: uuidv4(),
-              factName: '',
-              operator: 'equal',
-              value: '',
-            }),
-          ],
-        };
-        return newConditionSchema;
-      }
+    setLivingConditionSchema(buildNewSchemaWithAddition(livingConditionSchema, ruleGroupName, childTypeToAdd));
+  }, [livingConditionSchema, setLivingConditionSchema]);
 
-      Object.entries(existingSchema).forEach(([key, value]) => {
-        if (key === 'children' && value?.length) {
-          newConditionSchema = {
-            ...newConditionSchema,
-            children: value.map((ruleInformationObject) => buildNewSchema(ruleInformationObject)),
-          };
-
-          return;
-        }
-
-        newConditionSchema = {
-          ...newConditionSchema,
-          [key]: value,
-        };
-      });
-
-      return newConditionSchema;
-    };
-
-    setLivingConditionSchema(buildNewSchema(livingConditionSchema));
+  const removeChildFromGroup = React.useCallback((idToRemove) => {
+    setLivingConditionSchema(buildNewSchemaWithRemoval(livingConditionSchema, idToRemove));
   }, [livingConditionSchema, setLivingConditionSchema]);
 
   const ruleElements = React.useMemo(
     () => (
-      getRuleElementsFromSchema(livingConditionSchema, addChildToGroup, true)
-    ), [getRuleElementsFromSchema, livingConditionSchema, addChildToGroup],
+      getRuleElementsFromSchema(livingConditionSchema, addChildToGroup, removeChildFromGroup, true)
+    ), [getRuleElementsFromSchema, livingConditionSchema, addChildToGroup, removeChildFromGroup],
   );
 
   return (

--- a/src/components/RuleItem.js
+++ b/src/components/RuleItem.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Grid } from '@material-ui/core';
+import { Grid, IconButton } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
+import DeleteIcon from '@material-ui/icons/Delete';
 import { SQFormTextField, SQFormDropdown, useSQFormContext } from '@selectquotelabs/sqform';
 import OPERATOR_SQFORMDROPDOWN_OPTIONS from '../constants/operatorConstants';
 
@@ -13,10 +14,14 @@ const itemGridStyles = makeStyles({
     marginBottom: '25px',
     height: '80px',
   },
+  deleteIcon: {
+    padding: 0,
+  },
 });
 
 function RuleItem({
   ruleName,
+  removeRuleItem,
 }) {
   const itemClasses = itemGridStyles();
 
@@ -36,6 +41,11 @@ function RuleItem({
 
   return (
     <Grid container spacing={2} className={itemClasses.containerGrid}>
+      <Grid item sm={1}>
+        <IconButton className={itemClasses.deleteIcon} onClick={() => { removeRuleItem(ruleName); }}>
+          <DeleteIcon />
+        </IconButton>
+      </Grid>
       <SQFormTextField
         size={4}
         name={`${ruleName}_factName`}
@@ -43,7 +53,7 @@ function RuleItem({
         placeholder="Fact Name"
       />
       <SQFormDropdown
-        size={4}
+        size={3}
         name={`${ruleName}_operator`}
         label="Operator"
       >
@@ -62,6 +72,8 @@ function RuleItem({
 RuleItem.propTypes = {
   /** Name of this particular rule */
   ruleName: PropTypes.string.isRequired,
+  /** Function to delete rule */
+  removeRuleItem: PropTypes.func.isRequired,
 };
 
 export default RuleItem;

--- a/src/util/buildNewSchemaWithAddition.js
+++ b/src/util/buildNewSchemaWithAddition.js
@@ -1,0 +1,62 @@
+import { v4 as uuidv4 } from 'uuid';
+import { GROUP_TYPE, RULE_TYPE } from '../constants/constants';
+
+const getNewChildToAdd = (childTypeToAdd) => {
+  if (childTypeToAdd === GROUP_TYPE) {
+    return {
+      type: GROUP_TYPE,
+      id: uuidv4(),
+      condition: 'all',
+      children: [],
+    };
+  }
+
+  if (childTypeToAdd === RULE_TYPE) {
+    return {
+      type: RULE_TYPE,
+      id: uuidv4(),
+      factName: '',
+      operator: 'equal',
+      value: '',
+    };
+  }
+
+  return null;
+};
+
+const buildNewSchemaWithAddition = (existingSchema, ruleGroupName, childTypeToAdd) => {
+  let newConditionSchema = {};
+  if (existingSchema.id === ruleGroupName) {
+    newConditionSchema = {
+      ...newConditionSchema,
+      ...existingSchema,
+      children: [
+        ...existingSchema.children,
+        getNewChildToAdd(childTypeToAdd),
+      ],
+    };
+    return newConditionSchema;
+  }
+
+  Object.entries(existingSchema).forEach(([key, value]) => {
+    if (key === 'children' && value?.length) {
+      newConditionSchema = {
+        ...newConditionSchema,
+        children: value.map((ruleInformationObject) => (
+          buildNewSchemaWithAddition(ruleInformationObject, ruleGroupName, childTypeToAdd)
+        )),
+      };
+
+      return;
+    }
+
+    newConditionSchema = {
+      ...newConditionSchema,
+      [key]: value,
+    };
+  });
+
+  return newConditionSchema;
+};
+
+export default buildNewSchemaWithAddition;

--- a/src/util/buildNewSchemaWithRemoval.js
+++ b/src/util/buildNewSchemaWithRemoval.js
@@ -1,0 +1,33 @@
+const buildNewSchemaWithRemoval = (existingSchema, idToRemove) => {
+  let newConditionSchema = {};
+  if (existingSchema.id === idToRemove) {
+    if (existingSchema.children && existingSchema.children?.length) {
+      // TODO: Unable to remove.
+      return existingSchema;
+    }
+    return undefined;
+  }
+
+  Object.entries(existingSchema).forEach(([key, value]) => {
+    if (key === 'children' && value?.length) {
+      // Get children and filter out undefined
+      const newChildren = value
+        .map((ruleInformationObject) => buildNewSchemaWithRemoval(ruleInformationObject, idToRemove))
+        .filter((child) => !!child);
+
+      newConditionSchema = {
+        ...newConditionSchema,
+        children: newChildren,
+      };
+      return;
+    }
+
+    newConditionSchema = {
+      ...newConditionSchema,
+      [key]: value,
+    };
+  });
+  return newConditionSchema;
+};
+
+export default buildNewSchemaWithRemoval;

--- a/src/util/getRuleElementsFromSchema.js
+++ b/src/util/getRuleElementsFromSchema.js
@@ -3,7 +3,7 @@ import RuleGroup from '../components/RuleGroup';
 import RuleItem from '../components/RuleItem';
 import { TYPE_KEY, GROUP_TYPE, RULE_TYPE } from '../constants/constants';
 
-const getRuleElementsFromSchema = (schema, addChildToGroup, isFirstIteration) => {
+const getRuleElementsFromSchema = (schema, addChildToGroup, removeChildFromGroup, isFirstIteration) => {
   if (!schema) {
     return [];
   }
@@ -16,7 +16,7 @@ const getRuleElementsFromSchema = (schema, addChildToGroup, isFirstIteration) =>
           schema.children.forEach((child) => {
             childElements = [
               ...childElements,
-              ...getRuleElementsFromSchema(child, addChildToGroup, false),
+              ...getRuleElementsFromSchema(child, addChildToGroup, removeChildFromGroup, false),
             ];
           });
         }
@@ -27,6 +27,7 @@ const getRuleElementsFromSchema = (schema, addChildToGroup, isFirstIteration) =>
             key={`${schema.id}_ruleGroup`}
             ruleGroupName={schema.id}
             addChildToGroup={addChildToGroup}
+            removeRuleGroup={removeChildFromGroup}
             isTopGroup={isFirstIteration}
           >
             {childElements}
@@ -37,10 +38,10 @@ const getRuleElementsFromSchema = (schema, addChildToGroup, isFirstIteration) =>
       if (value === RULE_TYPE) {
         return [
           ...acc,
-
           <RuleItem
             key={`${schema.id}_ruleItem`}
             ruleName={schema.id}
+            removeRuleItem={removeChildFromGroup}
           />,
         ];
       }


### PR DESCRIPTION
## Description of changes

Added functionality to the "Remove" button so that groups can be removed from the schema _if_ they are empty. I also added a delete icon to each rule item that when clicked will remove the rule item from the group.

## Why?
We need to be able to remove rule items, and group. Duh.

## How was this change tested?

Tested it locally and seems to be working properly.

## UI change? Screenshots

## Other Notes