### PR TITLE
Convert rules engine schema to visualiser schema

### DIFF
--- a/src/util/engineSchemaToVisualisationSchema.js
+++ b/src/util/engineSchemaToVisualisationSchema.js
@@ -1,0 +1,41 @@
+import { v4 as uuidv4 } from 'uuid';
+import { GROUP_TYPE, RULE_TYPE } from '../constants/constants';
+
+const engineSchemaToVisualisationSchema = (engineSchema) => {
+  if (!engineSchema || typeof engineSchema !== 'object') {
+    return undefined;
+  }
+
+  const {
+    any, all, fact, operator, value,
+  } = engineSchema;
+
+  if (any || all) {
+    // Group
+    if ((any && !Array.isArray(any)) || (all && !Array.isArray(all))) {
+      return undefined;
+    }
+
+    return {
+      type: GROUP_TYPE,
+      id: uuidv4(),
+      condition: any ? 'any' : 'all',
+      children: (any || all).map((child) => engineSchemaToVisualisationSchema(child)),
+    };
+  }
+
+  if (fact !== undefined && operator !== undefined && value !== undefined) {
+    // Item
+    return {
+      type: RULE_TYPE,
+      id: uuidv4(),
+      factName: engineSchema.fact,
+      operator: engineSchema.operator,
+      value: engineSchema.value,
+    };
+  }
+
+  return undefined;
+};
+
+export default engineSchemaToVisualisationSchema;

--- a/stories/JSONRulesEngineVisualiser.stories.js
+++ b/stories/JSONRulesEngineVisualiser.stories.js
@@ -1,14 +1,36 @@
 import React from 'react';
 import Card from '@material-ui/core/Card';
-import { DEFAULT_CONDITION_SCHEMA } from '../src/constants/constants';
 import JSONRulesEngineVisualiser from '../src';
 
 export default {
   title: 'JSON Rules Engine Visualiser',
 };
 
+const TEST_ENGINE_SCHEMA = {
+  any: [{
+    fact: 'firstFact',
+    operator: 'equal',
+    value: 'firstValue',
+  },
+  {
+    all: [{
+      fact: 'secondFact',
+      operator: 'notEqual',
+      value: '5',
+    }],
+  },
+  {
+    all: [{
+      fact: 'thirdFact',
+      operator: 'equal',
+      value: '20',
+    }],
+  },
+  ],
+};
+
 export const visualiser = () => (
   <Card raised style={{ padding: 16, marginTop: 150 }}>
-    <JSONRulesEngineVisualiser conditionSchema={DEFAULT_CONDITION_SCHEMA} />
+    <JSONRulesEngineVisualiser conditionSchema={TEST_ENGINE_SCHEMA} />
   </Card>
 );


### PR DESCRIPTION
## Description of changes

The component now takes a schema in the shape of JSON Rules Engine JSON and massages it to what the visualiser understands. If there is an error parsing it then it defaults to a default value.

The submit button is disabled if any group has no children.

## How was this change tested?

Looking good locally in storybook and functionality appears to be working as expected.

## UI change? Screenshots

## Other Notes