### PR TITLE
Add optional fact name dropdown functionality

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -5,6 +5,7 @@ module.exports = {
   ],
   "addons": [
     "@storybook/addon-links",
-    "@storybook/addon-essentials"
+    "@storybook/addon-essentials",
+    "@storybook/addon-knobs"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2791,6 +2791,33 @@
         "ts-dedent": "^2.0.0"
       }
     },
+    "@storybook/addon-knobs": {
+      "version": "6.2.9",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-knobs/-/addon-knobs-6.2.9.tgz",
+      "integrity": "sha512-ic3xXy9uWPfIGP4x3VuGnrUmg/Jn9rHKIqZMhRcC7mFDRVlgbekvQxaruC6VY9LW6o8jV/miReSZkJf7M8o0aQ==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "6.2.9",
+        "@storybook/api": "6.2.9",
+        "@storybook/channels": "6.2.9",
+        "@storybook/client-api": "6.2.9",
+        "@storybook/components": "6.2.9",
+        "@storybook/core-events": "6.2.9",
+        "@storybook/theming": "6.2.9",
+        "copy-to-clipboard": "^3.3.1",
+        "core-js": "^3.8.2",
+        "escape-html": "^1.0.3",
+        "fast-deep-equal": "^3.1.3",
+        "global": "^4.4.0",
+        "lodash": "^4.17.20",
+        "prop-types": "^15.7.2",
+        "qs": "^6.10.0",
+        "react-colorful": "^5.0.1",
+        "react-lifecycles-compat": "^3.0.4",
+        "react-select": "^3.2.0",
+        "regenerator-runtime": "^0.13.7"
+      }
+    },
     "@storybook/addon-links": {
       "version": "6.2.9",
       "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-6.2.9.tgz",
@@ -16654,6 +16681,15 @@
         }
       }
     },
+    "react-input-autosize": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-3.0.0.tgz",
+      "integrity": "sha512-nL9uS7jEs/zu8sqwFE5MAPx6pPkNAriACQ2rGLlqmKr2sPGtN7TXTyDdQt4lbNXVx7Uzadb40x8qotIuru6Rhg==",
+      "dev": true,
+      "requires": {
+        "prop-types": "^15.5.8"
+      }
+    },
     "react-inspector": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-5.1.1.tgz",
@@ -16743,6 +16779,22 @@
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
       "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg=="
+    },
+    "react-select": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-3.2.0.tgz",
+      "integrity": "sha512-B/q3TnCZXEKItO0fFN/I0tWOX3WJvi/X2wtdffmwSQVRwg5BpValScTO1vdic9AxlUgmeSzib2hAZAwIUQUZGQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@emotion/cache": "^10.0.9",
+        "@emotion/core": "^10.0.9",
+        "@emotion/css": "^10.0.9",
+        "memoize-one": "^5.0.0",
+        "prop-types": "^15.6.0",
+        "react-input-autosize": "^3.0.0",
+        "react-transition-group": "^4.3.0"
+      }
     },
     "react-sizeme": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@pmmmwh/react-refresh-webpack-plugin": "^0.4.3",
     "@storybook/addon-actions": "^6.1.21",
     "@storybook/addon-essentials": "^6.1.21",
+    "@storybook/addon-knobs": "^6.2.9",
     "@storybook/addon-links": "^6.1.21",
     "@storybook/react": "^6.1.21",
     "babel-eslint": "^10.1.0",

--- a/src/components/JSONRulesEngineVisualiser.js
+++ b/src/components/JSONRulesEngineVisualiser.js
@@ -4,7 +4,7 @@ import { Grid } from '@material-ui/core';
 import { SQForm, SQFormButton } from '@selectquotelabs/sqform';
 import getInitialValuesFromSchema from '../util/getInitialValuesFromSchema';
 import getValidationSchemaFromSchema from '../util/getValidationSchemaFromSchema';
-import conditionSchemaPropType from '../util/proptypes';
+import { rulesEngineSchemaPropType } from '../util/proptypes';
 import buildJSONRulesEngineCondition from '../util/buildJSONRulesEngineCondition';
 import engineSchemaToVisualisationSchema from '../util/engineSchemaToVisualisationSchema';
 import { DEFAULT_CONDITION_SCHEMA } from '../constants/constants';
@@ -13,6 +13,7 @@ import RuleGroupDisplay from './RuleGroupDisplay';
 function JSONRulesEngineVisualiser({
   conditionSchema,
   onSubmit,
+  factNameDropdownOptions,
 }) {
   const [livingConditionSchema, setLivingConditionSchema] = React.useState(() => (
     engineSchemaToVisualisationSchema(conditionSchema) || DEFAULT_CONDITION_SCHEMA
@@ -63,6 +64,7 @@ function JSONRulesEngineVisualiser({
       <RuleGroupDisplay
         livingConditionSchema={livingConditionSchema}
         setLivingConditionSchema={setLivingConditionSchema}
+        factNameDropdownOptions={factNameDropdownOptions}
       />
       <Grid item sm={12}>
         <Grid container justify="flex-end">
@@ -74,8 +76,15 @@ function JSONRulesEngineVisualiser({
 }
 
 JSONRulesEngineVisualiser.propTypes = {
-  conditionSchema: conditionSchemaPropType,
+  /** Condition schema, json-rules-engine format */
+  conditionSchema: rulesEngineSchemaPropType,
+  /** Function to be called when schema is submitted. Should take a JSON object. */
   onSubmit: PropTypes.func.isRequired,
+  /** Options to be used for the fact dropdown. */
+  factNameDropdownOptions: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    value: PropTypes.oneOf([PropTypes.string, PropTypes.number, PropTypes.bool]).isRequired,
+  })),
 };
 
 export default JSONRulesEngineVisualiser;

--- a/src/components/RuleGroupDisplay.js
+++ b/src/components/RuleGroupDisplay.js
@@ -2,13 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Grid } from '@material-ui/core';
 import getRuleElementsFromSchema from '../util/getRuleElementsFromSchema';
-import conditionSchemaPropType from '../util/proptypes';
+import { visualiserSchemaPropType } from '../util/proptypes';
 import buildNewSchemaWithAddition from '../util/buildNewSchemaWithAddition';
 import buildNewSchemaWithRemoval from '../util/buildNewSchemaWithRemoval';
 
 function RuleGroupDisplay({
   livingConditionSchema,
   setLivingConditionSchema,
+  factNameDropdownOptions,
 }) {
   const addChildToGroup = React.useCallback((ruleGroupName, childTypeToAdd) => {
     setLivingConditionSchema(buildNewSchemaWithAddition(livingConditionSchema, ruleGroupName, childTypeToAdd));
@@ -20,8 +21,20 @@ function RuleGroupDisplay({
 
   const ruleElements = React.useMemo(
     () => (
-      getRuleElementsFromSchema(livingConditionSchema, addChildToGroup, removeChildFromGroup, true)
-    ), [getRuleElementsFromSchema, livingConditionSchema, addChildToGroup, removeChildFromGroup],
+      getRuleElementsFromSchema(
+        livingConditionSchema,
+        addChildToGroup,
+        removeChildFromGroup,
+        factNameDropdownOptions,
+        true,
+      )
+    ), [
+      getRuleElementsFromSchema,
+      livingConditionSchema,
+      addChildToGroup,
+      removeChildFromGroup,
+      factNameDropdownOptions,
+    ],
   );
 
   return (
@@ -32,8 +45,13 @@ function RuleGroupDisplay({
 }
 
 RuleGroupDisplay.propTypes = {
-  livingConditionSchema: conditionSchemaPropType,
+  livingConditionSchema: visualiserSchemaPropType,
   setLivingConditionSchema: PropTypes.func.isRequired,
+  /** Options to be used for the fact dropdown. */
+  factNameDropdownOptions: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    value: PropTypes.oneOf([PropTypes.string, PropTypes.number, PropTypes.bool]).isRequired,
+  })),
 };
 
 export default RuleGroupDisplay;

--- a/src/components/RuleItem.js
+++ b/src/components/RuleItem.js
@@ -22,6 +22,7 @@ const itemGridStyles = makeStyles({
 function RuleItem({
   ruleName,
   removeRuleItem,
+  factNameDropdownOptions,
 }) {
   const itemClasses = itemGridStyles();
 
@@ -39,6 +40,29 @@ function RuleItem({
     return null;
   }
 
+  const factField = React.useMemo(() => {
+    if (factNameDropdownOptions) {
+      return (
+        <SQFormDropdown
+          size={4}
+          name={`${ruleName}_factName`}
+          label="Fact Name"
+        >
+          {factNameDropdownOptions}
+        </SQFormDropdown>
+      );
+    }
+
+    return (
+      <SQFormTextField
+        size={4}
+        name={`${ruleName}_factName`}
+        label="Fact Name"
+        placeholder="Fact Name"
+      />
+    );
+  }, [factNameDropdownOptions]);
+
   return (
     <Grid container spacing={2} className={itemClasses.containerGrid}>
       <Grid item sm={1}>
@@ -46,12 +70,7 @@ function RuleItem({
           <DeleteIcon />
         </IconButton>
       </Grid>
-      <SQFormTextField
-        size={4}
-        name={`${ruleName}_factName`}
-        label="Fact Name"
-        placeholder="Fact Name"
-      />
+      {factField}
       <SQFormDropdown
         size={3}
         name={`${ruleName}_operator`}
@@ -74,6 +93,11 @@ RuleItem.propTypes = {
   ruleName: PropTypes.string.isRequired,
   /** Function to delete rule */
   removeRuleItem: PropTypes.func.isRequired,
+  /** Options to be used for the fact dropdown. */
+  factNameDropdownOptions: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    value: PropTypes.oneOf([PropTypes.string, PropTypes.number, PropTypes.bool]).isRequired,
+  })),
 };
 
 export default RuleItem;

--- a/src/util/getRuleElementsFromSchema.js
+++ b/src/util/getRuleElementsFromSchema.js
@@ -3,7 +3,13 @@ import RuleGroup from '../components/RuleGroup';
 import RuleItem from '../components/RuleItem';
 import { TYPE_KEY, GROUP_TYPE, RULE_TYPE } from '../constants/constants';
 
-const getRuleElementsFromSchema = (schema, addChildToGroup, removeChildFromGroup, isFirstIteration) => {
+const getRuleElementsFromSchema = (
+  schema,
+  addChildToGroup,
+  removeChildFromGroup,
+  factNameDropdownOptions,
+  isFirstIteration,
+) => {
   if (!schema) {
     return [];
   }
@@ -16,7 +22,13 @@ const getRuleElementsFromSchema = (schema, addChildToGroup, removeChildFromGroup
           schema.children.forEach((child) => {
             childElements = [
               ...childElements,
-              ...getRuleElementsFromSchema(child, addChildToGroup, removeChildFromGroup, false),
+              ...getRuleElementsFromSchema(
+                child,
+                addChildToGroup,
+                removeChildFromGroup,
+                factNameDropdownOptions,
+                false,
+              ),
             ];
           });
         }
@@ -42,6 +54,7 @@ const getRuleElementsFromSchema = (schema, addChildToGroup, removeChildFromGroup
             key={`${schema.id}_ruleItem`}
             ruleName={schema.id}
             removeRuleItem={removeChildFromGroup}
+            factNameDropdownOptions={factNameDropdownOptions}
           />,
         ];
       }

--- a/src/util/proptypes.js
+++ b/src/util/proptypes.js
@@ -1,6 +1,25 @@
 import PropTypes from 'prop-types';
 
-const rulePropType = (
+const rulesEngineRulePropType = (
+  PropTypes.exact({
+    fact: PropTypes.string.isRequired,
+    operator: PropTypes.string.isRequired,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.array]).isRequired,
+  }).isRequired
+);
+
+const rulesEngineGroupPropType = (
+  PropTypes.oneOfType([
+    PropTypes.shape({
+      any: PropTypes.arrayOf(PropTypes.oneOfType([rulesEngineRulePropType, PropTypes.object])).isRequired,
+    }),
+    PropTypes.shape({
+      all: PropTypes.arrayOf(PropTypes.oneOfType([rulesEngineRulePropType, PropTypes.object])).isRequired,
+    }),
+  ])
+);
+
+const visualiserSchemaRulePropType = (
   PropTypes.exact({
     type: PropTypes.oneOf(['rule']).isRequired,
     id: PropTypes.string.isRequired,
@@ -10,27 +29,27 @@ const rulePropType = (
   })
 );
 
-const groupPropType = (
+const visualiserSchemaGroupPropType = (
   PropTypes.shape({
     type: PropTypes.oneOf(['group']).isRequired,
     id: PropTypes.string.isRequired,
     condition: PropTypes.oneOf(['any', 'all']),
-    // Children should actually be another groupPropType or rulePropType
+    // Children should actually be another visualiserSchemaGroupPropType or visualiserSchemaRulePropType
     // Doing it this way prevents console warnings
     children: PropTypes.arrayOf(PropTypes.object),
   })
 );
 
-const conditionSchemaPropType = (
+export const visualiserSchemaPropType = (
   PropTypes.shape({
     type: PropTypes.oneOf(['group']).isRequired,
     id: PropTypes.string.isRequired,
     condition: PropTypes.oneOf(['any', 'all']),
     children: PropTypes.arrayOf(PropTypes.oneOfType([
-      groupPropType,
-      rulePropType,
+      visualiserSchemaGroupPropType,
+      visualiserSchemaRulePropType,
     ])),
-  })
+  }).isRequired
 );
 
-export default conditionSchemaPropType;
+export { rulesEngineGroupPropType as rulesEngineSchemaPropType };

--- a/stories/RulesEngineDemo.stories.js
+++ b/stories/RulesEngineDemo.stories.js
@@ -2,6 +2,8 @@ import React from 'react';
 import * as Yup from 'yup';
 import { Engine, Rule } from 'json-rules-engine';
 import { Card, Grid, Typography } from '@material-ui/core';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { withKnobs, boolean } from '@storybook/addon-knobs';
 import {
   SQForm, SQFormButton, SQFormDropdown, SQFormTextField,
 } from '@selectquotelabs/sqform';
@@ -9,6 +11,7 @@ import JSONRulesEngineVisualiser from '../src';
 
 export default {
   title: 'Rules Engine Demo',
+  decorators: [withKnobs],
 };
 
 const CAR_MAKES = [
@@ -59,6 +62,14 @@ const TEST_CONDITION_SCHEMA = {
   },
   ],
 };
+
+const factNameDropdownOptions = [
+  { label: 'Year', value: 'year' },
+  { label: 'Make', value: 'make' },
+  { label: 'Color', value: 'color' },
+  { label: 'State', value: 'state' },
+  { label: 'Mileage', value: 'mileage' },
+];
 
 const engine = new Engine();
 
@@ -124,7 +135,11 @@ export const rulesEngineDemo = () => {
     <Grid container spacing={2}>
       <Grid item sm={12}>
         <Card raised style={{ padding: 16, marginTop: 300 }}>
-          <JSONRulesEngineVisualiser conditionSchema={TEST_CONDITION_SCHEMA} onSubmit={handleRuleSubmit} />
+          <JSONRulesEngineVisualiser
+            conditionSchema={TEST_CONDITION_SCHEMA}
+            onSubmit={handleRuleSubmit}
+            factNameDropdownOptions={boolean('Use dropdown for fact name', false) ? factNameDropdownOptions : undefined}
+          />
         </Card>
       </Grid>
       <Grid item sm={12}>


### PR DESCRIPTION
## Description of changes
Added the ability for a dropdown to be used for the fact name instead of a free text field. The options *must* be provided and proper.
## Why?
<!--- Reference the relevant issue if applicable -->
Less error prone if the options are provided. Default is free text field.
## How was this change tested?

Tested locally with storybook and looks good. All submissions and what not work properly still.