### PR TITLE
Add functionality for custom operators

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@material-ui/lab": "^4.0.0-alpha.57",
     "@material-ui/pickers": "^4.0.0-alpha.11",
     "@selectquotelabs/sqform": "^4.0.0",
+    "@selectquotelabs/sqhooks": "^1.8.0",
     "json-rules-engine": "^6.0.1",
     "prop-types": "^15.7.2",
     "react": "^16.14.0",

--- a/src/components/JSONRulesEngineVisualiser.js
+++ b/src/components/JSONRulesEngineVisualiser.js
@@ -4,7 +4,11 @@ import { Grid } from '@material-ui/core';
 import { SQForm, SQFormButton } from '@selectquotelabs/sqform';
 import getInitialValuesFromSchema from '../util/getInitialValuesFromSchema';
 import { getValidationSchemaFromSchema } from '../util/getValidationSchemaFromSchema';
-import { rulesEngineSchemaPropType, valueDropdownOptionsPropType } from '../util/proptypes';
+import {
+  rulesEngineSchemaPropType,
+  operatorDropdownOptionsPropType,
+  valueDropdownOptionsPropType,
+} from '../util/proptypes';
 import buildJSONRulesEngineCondition from '../util/buildJSONRulesEngineCondition';
 import engineSchemaToVisualisationSchema from '../util/engineSchemaToVisualisationSchema';
 import { DEFAULT_CONDITION_SCHEMA } from '../constants/constants';
@@ -14,6 +18,7 @@ function JSONRulesEngineVisualiser({
   conditionSchema,
   onSubmit,
   factNameDropdownOptions,
+  operatorDropdownOptions,
   valueDropdownOptions,
 }) {
   const [livingConditionSchema, setLivingConditionSchema] = React.useState(() => (
@@ -75,6 +80,7 @@ function JSONRulesEngineVisualiser({
         livingConditionSchema={livingConditionSchema}
         setLivingConditionSchema={setLivingConditionSchema}
         factNameDropdownOptions={factNameDropdownOptions}
+        operatorDropdownOptions={operatorDropdownOptions}
         valueDropdownOptions={valueDropdownOptions}
         updateAllFactNames={updateAllFactNames}
       />
@@ -97,6 +103,8 @@ JSONRulesEngineVisualiser.propTypes = {
     label: PropTypes.string.isRequired,
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]).isRequired,
   })),
+  /** Options to be used for the operator dropdown */
+  operatorDropdownOptions: operatorDropdownOptionsPropType,
   /** Options to be used for the value dropdown */
   valueDropdownOptions: valueDropdownOptionsPropType,
 };

--- a/src/components/RuleGroupDisplay.js
+++ b/src/components/RuleGroupDisplay.js
@@ -2,7 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Grid } from '@material-ui/core';
 import getRuleElementsFromSchema from '../util/getRuleElementsFromSchema';
-import { visualiserSchemaPropType, valueDropdownOptionsPropType } from '../util/proptypes';
+import {
+  visualiserSchemaPropType,
+  valueDropdownOptionsPropType,
+  operatorDropdownOptionsPropType,
+} from '../util/proptypes';
 import buildNewSchemaWithAddition from '../util/buildNewSchemaWithAddition';
 import buildNewSchemaWithRemoval from '../util/buildNewSchemaWithRemoval';
 
@@ -10,6 +14,7 @@ function RuleGroupDisplay({
   livingConditionSchema,
   setLivingConditionSchema,
   factNameDropdownOptions,
+  operatorDropdownOptions,
   valueDropdownOptions,
   updateAllFactNames,
 }) {
@@ -28,6 +33,7 @@ function RuleGroupDisplay({
         addChildToGroup,
         removeChildFromGroup,
         factNameDropdownOptions,
+        operatorDropdownOptions,
         valueDropdownOptions,
         updateAllFactNames,
         true,
@@ -38,6 +44,7 @@ function RuleGroupDisplay({
       addChildToGroup,
       removeChildFromGroup,
       factNameDropdownOptions,
+      operatorDropdownOptions,
       valueDropdownOptions,
       updateAllFactNames,
     ],
@@ -58,6 +65,8 @@ RuleGroupDisplay.propTypes = {
     label: PropTypes.string.isRequired,
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]).isRequired,
   })),
+  /** Options to be used for the operator dropdown */
+  operatorDropdownOptions: operatorDropdownOptionsPropType,
   /** Options to be used for the value dropdown */
   valueDropdownOptions: valueDropdownOptionsPropType,
   /** Function to update all fact names */

--- a/src/components/RuleItem.js
+++ b/src/components/RuleItem.js
@@ -4,8 +4,9 @@ import { Grid, IconButton } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import DeleteIcon from '@material-ui/icons/Delete';
 import { SQFormTextField, SQFormDropdown, useSQFormContext } from '@selectquotelabs/sqform';
-import { valueDropdownOptionsPropType } from '../util/proptypes';
-import OPERATOR_SQFORMDROPDOWN_OPTIONS from '../constants/operatorConstants';
+import { operatorDropdownOptionsPropType, valueDropdownOptionsPropType } from '../util/proptypes';
+import DEFAULT_OPERATORS from '../constants/operatorConstants';
+import stringArrayToDropdownOptions from '../util/stringArrayToDropdownOptions';
 
 const itemGridStyles = makeStyles({
   containerGrid: {
@@ -24,9 +25,11 @@ function RuleItem({
   ruleName,
   removeRuleItem,
   factNameDropdownOptions,
+  operatorDropdownOptions,
   valueDropdownOptions,
   updateAllFactNames,
 }) {
+  const DEFAULT_OPERATOR_OPTIONS = stringArrayToDropdownOptions(DEFAULT_OPERATORS);
   const itemClasses = itemGridStyles();
 
   const { initialValues, values } = useSQFormContext();
@@ -71,6 +74,25 @@ function RuleItem({
       />
     );
   }, [factNameDropdownOptions]);
+
+  const operatorOptions = React.useMemo(() => {
+    if (!operatorDropdownOptions) {
+      return DEFAULT_OPERATOR_OPTIONS;
+    }
+
+    if (Array.isArray(operatorDropdownOptions)) {
+      return operatorDropdownOptions;
+    }
+
+    // If is an object
+    if (operatorDropdownOptions === Object(operatorDropdownOptions) && factNameDropdownOptions) {
+      if (!selectedFactName || operatorDropdownOptions[selectedFactName]) {
+        return operatorDropdownOptions[selectedFactName];
+      }
+    }
+
+    return DEFAULT_OPERATOR_OPTIONS;
+  }, [operatorDropdownOptions, factNameDropdownOptions]);
 
   const valueField = React.useMemo(() => {
     if (Array.isArray(valueDropdownOptions)) {
@@ -130,7 +152,7 @@ function RuleItem({
         name={`${ruleName}_operator`}
         label="Operator"
       >
-        {OPERATOR_SQFORMDROPDOWN_OPTIONS}
+        {operatorOptions}
       </SQFormDropdown>
       {valueField}
     </Grid>
@@ -147,6 +169,8 @@ RuleItem.propTypes = {
     label: PropTypes.string.isRequired,
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]).isRequired,
   })),
+  /** Options to be used for the operator dropdown */
+  operatorDropdownOptions: operatorDropdownOptionsPropType,
   /** Options to be used for the value dropdown */
   valueDropdownOptions: valueDropdownOptionsPropType,
   /** Function to update all fact names with new value */

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -56,22 +56,3 @@ export const DEFAULT_CONDITION_SCHEMA = {
     },
   ],
 };
-
-export const STRING_OPERATORS = [
-  'equal',
-  'notEqual',
-];
-
-export const NUMERIC_OPERATORS = [
-  'lessThan',
-  'lessThanInclusive',
-  'greaterThan',
-  'greaterThanInclusive',
-];
-
-export const ARRAY_OPERATORS = [
-  'in',
-  'notIn',
-  'contains',
-  'doesNotContain',
-];

--- a/src/constants/operatorConstants.js
+++ b/src/constants/operatorConstants.js
@@ -1,21 +1,47 @@
 /* Operators from: https://github.com/CacheControl/json-rules-engine/blob/v6.0.0/docs/rules.md#operators */
 /* As of json-rules-engine v6.0.0 */
 
+export const EQUAL_OPERATOR = 'equal';
+export const NOT_EQUAL_OPERATOR = 'notEqual';
+export const LESS_THAN_OPERATOR = 'lessThan';
+export const LESS_THAN_INCLUSIVE_OPERATOR = 'lessThanInclusive';
+export const GREATER_THAN_OPERATOR = 'greaterThan';
+export const GREATER_THAN_INCLUSIVE_OPERATOR = 'greaterThanInclusive';
+export const IN_OPERATOR = 'in';
+export const NOT_IN_OPERATOR = 'notIn';
+export const CONTAINS_OPERATOR = 'contains';
+export const DOES_NOT_CONTAIN_OPERATOR = 'doesNotContain';
+
 const OPERATORS = [
+  EQUAL_OPERATOR,
+  NOT_EQUAL_OPERATOR,
+  LESS_THAN_OPERATOR,
+  LESS_THAN_INCLUSIVE_OPERATOR,
+  GREATER_THAN_OPERATOR,
+  GREATER_THAN_INCLUSIVE_OPERATOR,
+  IN_OPERATOR,
+  NOT_IN_OPERATOR,
+  CONTAINS_OPERATOR,
+  DOES_NOT_CONTAIN_OPERATOR,
+];
+
+export const STRING_OPERATORS = [
   'equal',
   'notEqual',
+];
+
+export const NUMERIC_OPERATORS = [
   'lessThan',
   'lessThanInclusive',
   'greaterThan',
   'greaterThanInclusive',
+];
+
+export const ARRAY_OPERATORS = [
   'in',
   'notIn',
   'contains',
   'doesNotContain',
 ];
 
-const OPERATOR_SQFORMDROPDOWN_OPTIONS = OPERATORS.map((operator) => (
-  { label: operator, value: operator }
-));
-
-export default OPERATOR_SQFORMDROPDOWN_OPTIONS;
+export default OPERATORS;

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,17 @@
-export default from './components/JSONRulesEngineVisualiser';
+export { default as JSONRulesEngineVisualiser } from './components/JSONRulesEngineVisualiser';
+export {
+  default as defaultOperators,
+  EQUAL_OPERATOR as equalOperator,
+  NOT_EQUAL_OPERATOR as notEqualOperator,
+  LESS_THAN_OPERATOR as lessThanOperator,
+  LESS_THAN_INCLUSIVE_OPERATOR as lessThanInclusiveOperator,
+  GREATER_THAN_OPERATOR as greaterThanOperator,
+  GREATER_THAN_INCLUSIVE_OPERATOR as greaterThanInclusiveOperator,
+  IN_OPERATOR as inOperator,
+  NOT_IN_OPERATOR as notInOperator,
+  CONTAINS_OPERATOR as containsOperator,
+  DOES_NOT_CONTAIN_OPERATOR as doesNotContainOperator,
+  STRING_OPERATORS as commonStringOperators,
+  NUMERIC_OPERATORS as commonNumericOperators,
+  ARRAY_OPERATORS as commonArrayOperators,
+} from './constants/operatorConstants';

--- a/src/util/buildJSONRulesEngineCondition.js
+++ b/src/util/buildJSONRulesEngineCondition.js
@@ -1,4 +1,5 @@
-import { GROUP_TYPE, NUMERIC_OPERATORS, RULE_TYPE } from '../constants/constants';
+import { GROUP_TYPE, RULE_TYPE } from '../constants/constants';
+import { NUMERIC_OPERATORS } from '../constants/operatorConstants';
 
 const findValuesFromId = (id, type, formValues) => {
   if (type === GROUP_TYPE) {

--- a/src/util/getRuleElementsFromSchema.js
+++ b/src/util/getRuleElementsFromSchema.js
@@ -8,6 +8,7 @@ const getRuleElementsFromSchema = (
   addChildToGroup,
   removeChildFromGroup,
   factNameDropdownOptions,
+  operatorDropdownOptions,
   valueDropdownOptions,
   updateAllFactNames,
   isFirstIteration,
@@ -29,6 +30,7 @@ const getRuleElementsFromSchema = (
                 addChildToGroup,
                 removeChildFromGroup,
                 factNameDropdownOptions,
+                operatorDropdownOptions,
                 valueDropdownOptions,
                 updateAllFactNames,
                 false,
@@ -59,6 +61,7 @@ const getRuleElementsFromSchema = (
             ruleName={schema.id}
             removeRuleItem={removeChildFromGroup}
             factNameDropdownOptions={factNameDropdownOptions}
+            operatorDropdownOptions={operatorDropdownOptions}
             valueDropdownOptions={valueDropdownOptions}
             updateAllFactNames={updateAllFactNames}
           />,

--- a/src/util/proptypes.js
+++ b/src/util/proptypes.js
@@ -40,13 +40,49 @@ const visualiserSchemaGroupPropType = (
   })
 );
 
-/** Options to be used for the value dropdown
+/** Options to be used for the operator dropdown
  * The object should have a key for each value in the factNameDropdownOptions
- * prop that indicate the possible values for that fact to have seperate values
- * for each fact. factNameDropdownOptions is required for this to operate properly.
+ * prop that indicate the possible values for that fact. This allows for each fact to
+ * have different valid operator options.
+ * factNameDropdownOptions is required for this to operator properly
  *
  * Otherwise, an array of options can be passed that'll be used for all facts.
  *
+ * Not passing options will use all default operators
+ *
+ * An example can found in the RulesEngineDemo story
+ */
+
+export const operatorDropdownOptionsPropType = (
+  PropTypes.oneOfType([
+    PropTypes.objectOf(
+      PropTypes.arrayOf(
+        PropTypes.shape({
+          label: PropTypes.string.isRequired,
+          value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]).isRequired,
+        }),
+      ),
+    ),
+    PropTypes.arrayOf(
+      PropTypes.shape({
+        label: PropTypes.string.isRequired,
+        value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]).isRequired,
+      }),
+    ),
+  ])
+);
+
+/** Options to be used for the value dropdown
+ * The object should have a key for each value in the factNameDropdownOptions
+ * prop that indicate the possible values for that fact. This allow for each fact
+ * to have different valid value options.
+ * factNameDropdownOptions is required for this to operate properly.
+ *
+ * Otherwise, an array of options can be passed that'll be used for all facts.
+ *
+ * Not passing options will use the default free form text field.
+ *
+ * Examples can be found in the RulesEngineDemo story
  */
 export const valueDropdownOptionsPropType = (
   PropTypes.oneOfType([

--- a/src/util/stringArrayToDropdownOptions.js
+++ b/src/util/stringArrayToDropdownOptions.js
@@ -1,0 +1,6 @@
+export default function stringArrayToDropdownOptions(array) {
+  return array.map((item) => ({
+    label: item,
+    value: item,
+  }));
+}

--- a/stories/JSONRulesEngineVisualiser.stories.js
+++ b/stories/JSONRulesEngineVisualiser.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Card from '@material-ui/core/Card';
-import JSONRulesEngineVisualiser from '../src';
+import { JSONRulesEngineVisualiser } from '../src';
 
 export default {
   title: 'JSON Rules Engine Visualiser',

--- a/stories/RulesEngineDemo.stories.js
+++ b/stories/RulesEngineDemo.stories.js
@@ -7,7 +7,18 @@ import { withKnobs, boolean } from '@storybook/addon-knobs';
 import {
   SQForm, SQFormButton, SQFormDropdown, SQFormTextField,
 } from '@selectquotelabs/sqform';
-import JSONRulesEngineVisualiser from '../src';
+import { JSONRulesEngineVisualiser } from '../src';
+import {
+  EQUAL_OPERATOR,
+  GREATER_THAN_INCLUSIVE_OPERATOR,
+  GREATER_THAN_OPERATOR,
+  LESS_THAN_INCLUSIVE_OPERATOR,
+  LESS_THAN_OPERATOR,
+  NOT_EQUAL_OPERATOR,
+  NUMERIC_OPERATORS,
+  STRING_OPERATORS,
+} from '../src/constants/operatorConstants';
+import stringArrayToDropdownOptions from '../src/util/stringArrayToDropdownOptions';
 
 export default {
   title: 'Rules Engine Demo',
@@ -71,7 +82,24 @@ const factNameDropdownOptions = [
   { label: 'Mileage', value: 'mileage' },
 ];
 
-const generalFactNameDropdownOptions = [
+const generalOperatorDropdownOptions = stringArrayToDropdownOptions([
+  EQUAL_OPERATOR,
+  NOT_EQUAL_OPERATOR,
+  LESS_THAN_OPERATOR,
+  LESS_THAN_INCLUSIVE_OPERATOR,
+  GREATER_THAN_OPERATOR,
+  GREATER_THAN_INCLUSIVE_OPERATOR,
+]);
+
+const specificOperatorDropdownOptions = {
+  year: stringArrayToDropdownOptions(NUMERIC_OPERATORS),
+  make: stringArrayToDropdownOptions(STRING_OPERATORS),
+  color: stringArrayToDropdownOptions(STRING_OPERATORS),
+  state: stringArrayToDropdownOptions(STRING_OPERATORS),
+  mileage: stringArrayToDropdownOptions(NUMERIC_OPERATORS),
+};
+
+const generalValueDropdownOptions = [
   ...CAR_COLORS,
   ...CAR_MAKES,
   ...STATES,
@@ -84,7 +112,7 @@ const generalFactNameDropdownOptions = [
   { label: '200001', value: '200001' },
 ];
 
-const specificFactNameDropdownOptions = {
+const specificValueOptionDropdowns = {
   year: [
     { label: '2010', value: '2010' },
     { label: '2016', value: '2016' },
@@ -163,13 +191,21 @@ export const rulesEngineDemo = () => {
           <JSONRulesEngineVisualiser
             conditionSchema={TEST_CONDITION_SCHEMA}
             onSubmit={handleRuleSubmit}
-            factNameDropdownOptions={boolean('Use dropdown for fact name', false) ? factNameDropdownOptions : undefined}
+            factNameDropdownOptions={boolean('Use dropdown for FACT NAME', false) ? factNameDropdownOptions : undefined}
+            operatorDropdownOptions={
+              /* eslint-disable-next-line no-nested-ternary */
+              boolean('Use dropdown options for OPERATOR', false)
+                ? (boolean('Use specific dropdown options for OPERATOR', false)
+                  ? specificOperatorDropdownOptions
+                  : generalOperatorDropdownOptions)
+                : undefined
+            }
             valueDropdownOptions={
               /* eslint-disable-next-line no-nested-ternary */
-              boolean('Use dropdown options for value', false)
-                ? (boolean('Use specific dropdown options for value', false)
-                  ? specificFactNameDropdownOptions
-                  : generalFactNameDropdownOptions)
+              boolean('Use dropdown options for VALUE', false)
+                ? (boolean('Use specific dropdown options for VALUE', false)
+                  ? specificValueOptionDropdowns
+                  : generalValueDropdownOptions)
                 : undefined
             }
           />


### PR DESCRIPTION
## Description of changes

Added functionality for the consumer to provide which operators they want for which factnames OR to simply just provide which operators they want. As a byproduct this also allows for custom operators

## Why?
<!--- Reference the relevant issue if applicable -->

This will help cover more use cases and make the UI more robust for use and less error prone

## How was this change tested?

Storybook example is looking good

## Other Notes

Closes #16 
Closes #17 